### PR TITLE
Use proper autoload naming scheme

### DIFF
--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -191,7 +191,7 @@ function! s:GetJumpCol(jump_tree) " {{{
 endfunction
 " }}}
 
-function! core#DoCharMotion(motion, mode) " {{{
+function! snipe#core#DoCharMotion(motion, mode) " {{{
   " returns 1 if the motion was successful, 0 in case
   " there was nowhere to jump to or the jump was cancelled
   let ord = s:GetInput( 'Enter target character: ')
@@ -234,7 +234,7 @@ function! s:GetWordHits(motion) " {{{
 endfunction
 " }}}
 
-function! core#DoWordMotion(motion, mode) " {{{
+function! snipe#core#DoWordMotion(motion, mode) " {{{
   if !has_key(s:known_modes, a:mode)
     return
   endif
@@ -267,10 +267,10 @@ function! s:Jump(jump_col, mode) " {{{
 endfunction
 " }}}
 
-function! core#DoSwap(motion) " {{{
+function! snipe#core#DoSwap(motion) " {{{
   function! DoSwap(...)
     let saved = @"
-    let did_jump = core#DoCharMotion(a:1, '')
+    let did_jump = snipe#core#DoCharMotion(a:1, '')
     if did_jump
       normal xp
     endif
@@ -280,9 +280,9 @@ function! core#DoSwap(motion) " {{{
 endfunction
 " }}}
 
-function! core#DoCut(motion) " {{{
+function! snipe#core#DoCut(motion) " {{{
   function! DoCut(...)
-    let did_jump = core#DoCharMotion(a:1, '')
+    let did_jump = snipe#core#DoCharMotion(a:1, '')
     if did_jump
       normal "_x
     endif
@@ -291,9 +291,9 @@ function! core#DoCut(motion) " {{{
 endfunction
 " }}}
 
-function! core#DoReplace(motion) " {{{
+function! snipe#core#DoReplace(motion) " {{{
   function! DoReplace(...)
-    let did_jump = core#DoCharMotion(a:1, '')
+    let did_jump = snipe#core#DoCharMotion(a:1, '')
     if !did_jump
       return
     endif

--- a/autoload/snipe/highlight.vim
+++ b/autoload/snipe/highlight.vim
@@ -22,7 +22,7 @@ function! s:InitializeHLGroup(hl_group_name, colors) " TODO: understand me! {{{
   execute printf('hi default link %s %s', a:hl_group_name, default_hl_group_name)
 endfunction " }}}
 
-function! highlight#InitializeHLGroups()
+function! snipe#highlight#InitializeHLGroups()
   " wrapper function that exists to provide further highlighting
   call <SID>InitializeHLGroup(g:snipe_hl1_group, s:hl1_group_colors)
 endfunction

--- a/plugin/snipe.vim
+++ b/plugin/snipe.vim
@@ -1,54 +1,54 @@
 " character motions
-nnoremap <script> <Plug>(snipe-f) :call core#DoCharMotion('f', '')<CR>
-nnoremap <script> <Plug>(snipe-F) :call core#DoCharMotion('F', '')<CR>
-nnoremap <script> <Plug>(snipe-t) :call core#DoCharMotion('t', '')<CR>
-nnoremap <script> <Plug>(snipe-T) :call core#DoCharMotion('T', '')<CR>
-vnoremap <script> <Plug>(snipe-f) :<c-u>call core#DoCharMotion('f', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-F) :<c-u>call core#DoCharMotion('F', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-t) :<c-u>call core#DoCharMotion('t', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-T) :<c-u>call core#DoCharMotion('T', visualmode())<CR>
-onoremap <script> <Plug>(snipe-f) :call core#DoCharMotion('f', mode(1))<CR>
-onoremap <script> <Plug>(snipe-F) :call core#DoCharMotion('F', mode(1))<CR>
-onoremap <script> <Plug>(snipe-t) :call core#DoCharMotion('t', mode(1))<CR>
-onoremap <script> <Plug>(snipe-T) :call core#DoCharMotion('T', mode(1))<CR>
+nnoremap <script> <Plug>(snipe-f) :call snipe#core#DoCharMotion('f', '')<CR>
+nnoremap <script> <Plug>(snipe-F) :call snipe#core#DoCharMotion('F', '')<CR>
+nnoremap <script> <Plug>(snipe-t) :call snipe#core#DoCharMotion('t', '')<CR>
+nnoremap <script> <Plug>(snipe-T) :call snipe#core#DoCharMotion('T', '')<CR>
+vnoremap <script> <Plug>(snipe-f) :<c-u>call snipe#core#DoCharMotion('f', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-F) :<c-u>call snipe#core#DoCharMotion('F', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-t) :<c-u>call snipe#core#DoCharMotion('t', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-T) :<c-u>call snipe#core#DoCharMotion('T', visualmode())<CR>
+onoremap <script> <Plug>(snipe-f) :call snipe#core#DoCharMotion('f', mode(1))<CR>
+onoremap <script> <Plug>(snipe-F) :call snipe#core#DoCharMotion('F', mode(1))<CR>
+onoremap <script> <Plug>(snipe-t) :call snipe#core#DoCharMotion('t', mode(1))<CR>
+onoremap <script> <Plug>(snipe-T) :call snipe#core#DoCharMotion('T', mode(1))<CR>
 
 " word motions
-nnoremap <script> <Plug>(snipe-w)  :call core#DoWordMotion('w', '')<CR>
-nnoremap <script> <Plug>(snipe-W)  :call core#DoWordMotion('W', '')<CR>
-nnoremap <script> <Plug>(snipe-e)  :call core#DoWordMotion('e', '')<CR>
-nnoremap <script> <Plug>(snipe-E)  :call core#DoWordMotion('E', '')<CR>
-nnoremap <script> <Plug>(snipe-b)  :call core#DoWordMotion('b', '')<CR>
-nnoremap <script> <Plug>(snipe-B)  :call core#DoWordMotion('B', '')<CR>
-nnoremap <script> <Plug>(snipe-ge) :call core#DoWordMotion('ge', '')<CR>
-nnoremap <script> <Plug>(snipe-gE) :call core#DoWordMotion('gE', '')<CR>
-vnoremap <script> <Plug>(snipe-w)  :<c-u>call core#DoWordMotion('w', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-W)  :<c-u>call core#DoWordMotion('W', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-e)  :<c-u>call core#DoWordMotion('e', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-E)  :<c-u>call core#DoWordMotion('E', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-b)  :<c-u>call core#DoWordMotion('b', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-B)  :<c-u>call core#DoWordMotion('B', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-ge) :<c-u>call core#DoWordMotion('ge', visualmode())<CR>
-vnoremap <script> <Plug>(snipe-gE) :<c-u>call core#DoWordMotion('gE', visualmode())<CR>
-onoremap <script> <Plug>(snipe-w)  :call core#DoWordMotion('w', mode(1))<CR>
-onoremap <script> <Plug>(snipe-W)  :call core#DoWordMotion('W', mode(1))<CR>
-onoremap <script> <Plug>(snipe-e)  :call core#DoWordMotion('e', mode(1))<CR>
-onoremap <script> <Plug>(snipe-E)  :call core#DoWordMotion('E', mode(1))<CR>
-onoremap <script> <Plug>(snipe-b)  :call core#DoWordMotion('b', mode(1))<CR>
-onoremap <script> <Plug>(snipe-B)  :call core#DoWordMotion('B', mode(1))<CR>
-onoremap <script> <Plug>(snipe-ge) :call core#DoWordMotion('ge', mode(1))<CR>
-onoremap <script> <Plug>(snipe-gE) :call core#DoWordMotion('gE', mode(1))<CR>
+nnoremap <script> <Plug>(snipe-w)  :call snipe#core#DoWordMotion('w', '')<CR>
+nnoremap <script> <Plug>(snipe-W)  :call snipe#core#DoWordMotion('W', '')<CR>
+nnoremap <script> <Plug>(snipe-e)  :call snipe#core#DoWordMotion('e', '')<CR>
+nnoremap <script> <Plug>(snipe-E)  :call snipe#core#DoWordMotion('E', '')<CR>
+nnoremap <script> <Plug>(snipe-b)  :call snipe#core#DoWordMotion('b', '')<CR>
+nnoremap <script> <Plug>(snipe-B)  :call snipe#core#DoWordMotion('B', '')<CR>
+nnoremap <script> <Plug>(snipe-ge) :call snipe#core#DoWordMotion('ge', '')<CR>
+nnoremap <script> <Plug>(snipe-gE) :call snipe#core#DoWordMotion('gE', '')<CR>
+vnoremap <script> <Plug>(snipe-w)  :<c-u>call snipe#core#DoWordMotion('w', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-W)  :<c-u>call snipe#core#DoWordMotion('W', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-e)  :<c-u>call snipe#core#DoWordMotion('e', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-E)  :<c-u>call snipe#core#DoWordMotion('E', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-b)  :<c-u>call snipe#core#DoWordMotion('b', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-B)  :<c-u>call snipe#core#DoWordMotion('B', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-ge) :<c-u>call snipe#core#DoWordMotion('ge', visualmode())<CR>
+vnoremap <script> <Plug>(snipe-gE) :<c-u>call snipe#core#DoWordMotion('gE', visualmode())<CR>
+onoremap <script> <Plug>(snipe-w)  :call snipe#core#DoWordMotion('w', mode(1))<CR>
+onoremap <script> <Plug>(snipe-W)  :call snipe#core#DoWordMotion('W', mode(1))<CR>
+onoremap <script> <Plug>(snipe-e)  :call snipe#core#DoWordMotion('e', mode(1))<CR>
+onoremap <script> <Plug>(snipe-E)  :call snipe#core#DoWordMotion('E', mode(1))<CR>
+onoremap <script> <Plug>(snipe-b)  :call snipe#core#DoWordMotion('b', mode(1))<CR>
+onoremap <script> <Plug>(snipe-B)  :call snipe#core#DoWordMotion('B', mode(1))<CR>
+onoremap <script> <Plug>(snipe-ge) :call snipe#core#DoWordMotion('ge', mode(1))<CR>
+onoremap <script> <Plug>(snipe-gE) :call snipe#core#DoWordMotion('gE', mode(1))<CR>
 
 " editing motions
-nnoremap <script> <Plug>(snipe-f-xp) :call core#DoSwap('f')<CR>
-nnoremap <script> <Plug>(snipe-F-xp) :call core#DoSwap('F')<CR>
-nnoremap <script> <Plug>(snipe-f-x) :call core#DoCut('f')<CR>
-nnoremap <script> <Plug>(snipe-F-x) :call core#DoCut('F')<CR>
-nnoremap <script> <Plug>(snipe-f-r) :call core#DoReplace('f')<CR>
-nnoremap <script> <Plug>(snipe-F-r) :call core#DoReplace('F')<CR>
+nnoremap <script> <Plug>(snipe-f-xp) :call snipe#core#DoSwap('f')<CR>
+nnoremap <script> <Plug>(snipe-F-xp) :call snipe#core#DoSwap('F')<CR>
+nnoremap <script> <Plug>(snipe-f-x) :call snipe#core#DoCut('f')<CR>
+nnoremap <script> <Plug>(snipe-F-x) :call snipe#core#DoCut('F')<CR>
+nnoremap <script> <Plug>(snipe-f-r) :call snipe#core#DoReplace('f')<CR>
+nnoremap <script> <Plug>(snipe-F-r) :call snipe#core#DoReplace('F')<CR>
 
-call highlight#InitializeHLGroups()
+call snipe#highlight#InitializeHLGroups()
 
 augroup SmartMotionInitializeHL
   autocmd!
-  autocmd ColorScheme * call highlight#InitializeHLGroups()
+  autocmd ColorScheme * call snipe#highlight#InitializeHLGroups()
 augroup end


### PR DESCRIPTION
This reduce vector for name conflicts with other plugins by scoping all
functions using plugin name.

Close #5 