### PR TITLE
Fixed missing 'j' in g:snipe_jump_tokens

### DIFF
--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -17,7 +17,7 @@ let s:forward_motions = {
       \  'E': 1,
       \}
 if !exists('g:snipe_jump_tokens')
-  let g:snipe_jump_tokens = 'asdfghklqwertyuiopzxcvbnm'
+  let g:snipe_jump_tokens = 'asdfghjklqwertyuiopzxcvbnm'
 endif
 " }}}
 


### PR DESCRIPTION
Sorry about the previous PR. This one should be good.