### PR TITLE
Multi-keystroke sequence now only display the first letter

### DIFF
--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -20,6 +20,9 @@ let s:forward_motions = {
 if !exists('g:snipe_jump_tokens')
   let g:snipe_jump_tokens = 'asdfghjklqwertyuiopzxcvbnm'
 endif
+if !exists('g:snipe_display_full_jump_seq')
+  let g:snipe_display_full_jump_seq = 0
+endif
 " }}}
 
 function! s:GetHitCounts(hits_rem) " {{{
@@ -168,6 +171,9 @@ function! s:GetJumpCol(jump_tree) " {{{
   for [jump_seq, jump_col] in jump_items
     " this loop builds the highlighted line, adding highlights from left to right;
     " previous multi-token jump sequences are accounted for by tracking col_offset.
+    if !g:snipe_display_full_jump_seq
+        let jump_seq = jump_seq[0]
+    endif
     let len_jump_seq = strlen(jump_seq)
     let hl_start_col = jump_col + col_offset
     let hl_line = substitute(hl_line, '\%' . hl_start_col . 'c.', jump_seq, '')

--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -20,9 +20,6 @@ let s:forward_motions = {
 if !exists('g:snipe_jump_tokens')
   let g:snipe_jump_tokens = 'asdfghjklqwertyuiopzxcvbnm'
 endif
-if !exists('g:snipe_display_full_jump_seq')
-  let g:snipe_display_full_jump_seq = 0
-endif
 " }}}
 
 function! s:GetHitCounts(hits_rem) " {{{
@@ -167,22 +164,11 @@ function! s:GetJumpCol(jump_tree) " {{{
 
   let jump_items = items(jump_dict)
   call sort(jump_items, 'SortAscByJumpCol')
-  let col_offset = 0
   for [jump_seq, jump_col] in jump_items
     " this loop builds the highlighted line, adding highlights from left to right;
-    " previous multi-token jump sequences are accounted for by tracking col_offset.
-    if !g:snipe_display_full_jump_seq
-        let jump_seq = jump_seq[0]
-    endif
-    let len_jump_seq = strlen(jump_seq)
-    let hl_start_col = jump_col + col_offset
-    let hl_line = substitute(hl_line, '\%' . hl_start_col . 'c.', jump_seq, '')
-    let hl_cols = map(
-    \  range(hl_start_col, hl_start_col + len_jump_seq - 1),
-    \  '[' . lnum . ',v:val]'
-    \)
-    call add(hl_ids, matchaddpos(g:snipe_hl1_group, hl_cols))
-    let col_offset += len_jump_seq - 1
+    " multi-token jump sequences will only show the first token.
+    let hl_line = substitute(hl_line, '\%' . jump_col . 'c.', jump_seq[0], '')
+    call add(hl_ids, matchaddpos(g:snipe_hl1_group, [[lnum, jump_col]]))
   endfor
 
   let modified = &modified

--- a/doc/snipe.txt
+++ b/doc/snipe.txt
@@ -60,6 +60,9 @@ cognitive load.
 ====================================================================
 CONFIGURATION                                           *snipe-config*
 
+--------------------------------------------------------------------
+                                                *g:snipe_jump_tokens*
+
 By default, the jump tokens are ordered starting with the home row
 {asdfghjkl}, then {qwertyuiop}, then {zxcvbnm}. You can provide your
 own sequence by setting a global variable `g:snipe_jump_tokens`. For
@@ -67,6 +70,11 @@ Dvorak users, e.g.
 >
     let g:snipe_jump_tokens = 'aoeuidhtns'
 <
+--------------------------------------------------------------------
+                                         *g:snipe_highlight_gui_color*
+                                    *g:snipe_highlight_cterm256_color*
+                                       *g:snipe_highlight_cterm_color*
+
 The jump tokens are highlighted in a configurable color. The
 default colors are #fabd2f for gui mode and 7 (light grey). To
 override these values, specify the the variables (for gui mode and
@@ -75,6 +83,29 @@ terminal mode respectively):
     let g:snipe_highlight_gui_color      = '#dfffaf'
     let g:snipe_highlight_cterm256_color = 'blue'
     let g:snipe_highlight_cterm_color    = 'red'
+
+--------------------------------------------------------------------
+                                       *g:snipe_display_full_jump_seq*
+
+If a motion has more possibilities than the number of jump tokens
+specified by |g:snipe_jump_tokens|, then the sequence will contain
+multiple keystrokes. By default, it will only display the first
+keystroke, and display subsequent ones after the first keypress.
+However, you can override it by setting `g:snipe_display_full_jump_seq`:
+>
+    let g:snipe_display_full_jump_seq = 1
+<
+Doing so will show the full keystroke sequence, potentially shifting the
+column positions of the text in the display. For example, if
+`g:snipe_jump_tokens` is set to `'asd'`, and the current line is `" 12 34 56 78"`,
+then if you |snipe-w| from the beginning of the line, by default it will look
+like:
+>
+     a2 s4 d6 d8
+<
+With `g:snipe_display_full_jump_seq` set, it will look like:
+>
+     a2 s4 da6 ds8
 <
 ====================================================================
 CHARACTER MOTIONS                                 *snipe-char-motions*

--- a/doc/snipe.txt
+++ b/doc/snipe.txt
@@ -83,29 +83,6 @@ terminal mode respectively):
     let g:snipe_highlight_gui_color      = '#dfffaf'
     let g:snipe_highlight_cterm256_color = 'blue'
     let g:snipe_highlight_cterm_color    = 'red'
-
---------------------------------------------------------------------
-                                       *g:snipe_display_full_jump_seq*
-
-If a motion has more possibilities than the number of jump tokens
-specified by |g:snipe_jump_tokens|, then the sequence will contain
-multiple keystrokes. By default, it will only display the first
-keystroke, and display subsequent ones after the first keypress.
-However, you can override it by setting `g:snipe_display_full_jump_seq`:
->
-    let g:snipe_display_full_jump_seq = 1
-<
-Doing so will show the full keystroke sequence, potentially shifting the
-column positions of the text in the display. For example, if
-`g:snipe_jump_tokens` is set to `'asd'`, and the current line is `" 12 34 56 78"`,
-then if you |snipe-w| from the beginning of the line, by default it will look
-like:
->
-     a2 s4 d6 d8
-<
-With `g:snipe_display_full_jump_seq` set, it will look like:
->
-     a2 s4 da6 ds8
 <
 ====================================================================
 CHARACTER MOTIONS                                 *snipe-char-motions*


### PR DESCRIPTION
This avoids shifting column positions of the line in multi-keystroke sequences. Provide option to display the entire sequence like before.

Personally I found the new defaults to make a lot more sense. If you prefer me to use the old defaults instead, I can definitely change the new behavior to be only turned on by the option.

Resolves #18 