### PR TITLE
Prevent from remapping normal commands

### DIFF
--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -197,7 +197,7 @@ endfunction
 function! s:GetInput(message) " {{{
   redraw | echo a:message
   let ord = getchar()
-  normal :<c-u>
+  normal! :<c-u>
   return ord
 endfunction
 " }}}


### PR DESCRIPTION
I have remapped `:` so I encounted some wierd behaviors during using this plugin.

`normal!` is more safe.

@yangmillstheory PTAL