### PR TITLE
Change snipe#core#DoCut to not use mappings anymore

### DIFF
--- a/autoload/snipe/core.vim
+++ b/autoload/snipe/core.vim
@@ -366,7 +366,7 @@ function! snipe#core#DoCut(motion) " {{{
   function! DoCut(...)
     let did_jump = snipe#core#DoCharMotion(a:1, '')
     if did_jump
-      normal "_x
+      normal! "_x
     endif
   endfunction
   call DoAndGoBack(function('DoCut', [a:motion]))


### PR DESCRIPTION
Use `normal!` instead of `normal` to execute `"_x` so that mappings are ignored.